### PR TITLE
Indexed events

### DIFF
--- a/contracts/SwapyExchange.sol
+++ b/contracts/SwapyExchange.sol
@@ -45,12 +45,11 @@ contract SwapyExchange {
       uint256 _paybackDays,
       uint256 _grossReturn,
       string _currency,
-      bytes _offerTermsHash,
       uint256[] _assets)
     public
     returns(bool)
   {
-    address[] memory newAssets = createOfferAssets(_assets, _currency, _offerTermsHash, _paybackDays, _grossReturn);
+    address[] memory newAssets = createOfferAssets(_assets, _currency, _paybackDays, _grossReturn);
     Offers(msg.sender, VERSION, newAssets);
     return true;
   }
@@ -58,7 +57,6 @@ contract SwapyExchange {
   function createOfferAssets(
       uint256[] _assets,
       string _currency,
-      bytes _offerTermsHash,
       uint _paybackDays,
       uint _grossReturn)
     internal
@@ -73,7 +71,6 @@ contract SwapyExchange {
         VERSION,
         _currency,
         _assets[index],
-        _offerTermsHash,
         _paybackDays,
         _grossReturn,
         token

--- a/contracts/SwapyExchange.sol
+++ b/contracts/SwapyExchange.sol
@@ -46,7 +46,7 @@ contract SwapyExchange {
       uint256 _grossReturn,
       string _currency,
       uint256[] _assets)
-    public
+    external
     returns(bool)
   {
     address[] memory newAssets = createOfferAssets(_assets, _currency, _paybackDays, _grossReturn);
@@ -80,7 +80,7 @@ contract SwapyExchange {
   }
 
   function invest(address[] _assets) payable
-    public
+    external
     returns(bool)
   {
     uint256 assetValue = msg.value / _assets.length;
@@ -92,7 +92,7 @@ contract SwapyExchange {
   }
 
   function sellAsset(address _asset, uint256 _value)
-    public
+    external
     returns(bool)
   {
     InvestmentAsset asset = InvestmentAsset(_asset);
@@ -103,7 +103,7 @@ contract SwapyExchange {
   }
 
   function buyAsset(address _asset) payable
-    public
+    external
     returns(bool)
   {
     uint256 assetValue = msg.value;

--- a/contracts/SwapyExchange.sol
+++ b/contracts/SwapyExchange.sol
@@ -10,25 +10,25 @@ contract SwapyExchange {
   address public token;
 
   event Offers(
-    address _from,
+    address indexed _from,
     string _protocolVersion,
     address[] _assets
   );
 
   event Investments(
-    address _investor,
+    address indexed _investor,
     address[] _assets,
     uint256 _value
   );
 
   event ForSale(
-    address _investor,
+    address indexed _investor,
     address _asset,
     uint256 _value
   );
 
   event Bought(
-    address _buyer,
+    address indexed _buyer,
     address _asset,
     uint256 _value
   );

--- a/contracts/investment/AssetLibrary.sol
+++ b/contracts/investment/AssetLibrary.sol
@@ -22,8 +22,6 @@ contract AssetLibrary is AssetEvents {
     address public investor;
     // Protocol version
     string public protocolVersion;
-    // Contractual terms hash of investment
-    bytes public assetTermsHash;
     // investment timestamp
     uint public investedAt;
     

--- a/contracts/investment/AssetLibrary.sol
+++ b/contracts/investment/AssetLibrary.sol
@@ -81,7 +81,7 @@ contract AssetLibrary is AssetEvents {
 
     function isDelayed()
         view
-        public
+        internal
         returns(bool)
     {
         return now > investedAt + paybackDays * 1 days;
@@ -117,7 +117,7 @@ contract AssetLibrary is AssetEvents {
     // Add investment interest in this asset and retain the funds within the smart contract
     function invest(address _investor) payable
          hasStatus(Status.AVAILABLE)
-         public
+         external
          returns(bool)
     {
         investor = _investor;
@@ -131,7 +131,7 @@ contract AssetLibrary is AssetEvents {
     function cancelInvestment()
         onlyInvestor
         hasStatus(Status.PENDING_OWNER_AGREEMENT)
-        public
+        external
         returns(bool)
     {
         var (currentInvestor, investedValue) = makeAvailable();
@@ -143,7 +143,7 @@ contract AssetLibrary is AssetEvents {
     function withdrawFunds()
         onlyOwner
         hasStatus(Status.PENDING_OWNER_AGREEMENT)
-        public
+        external
         returns(bool)
     {
         uint256 _value = this.balance;
@@ -157,7 +157,7 @@ contract AssetLibrary is AssetEvents {
     function refuseInvestment()
         onlyOwner
         hasStatus(Status.PENDING_OWNER_AGREEMENT)
-        public
+        external
         returns(bool)
     {
         var (currentInvestor, investedValue) = makeAvailable();
@@ -168,7 +168,7 @@ contract AssetLibrary is AssetEvents {
     function sell(uint256 _sellValue) 
         authorizedToSell
         hasStatus(Status.INVESTED)
-        public
+        external
         returns(bool)
     {
         sellData.value = _sellValue;
@@ -180,7 +180,7 @@ contract AssetLibrary is AssetEvents {
     function cancelSellOrder() 
         authorizedToSell
         hasStatus(Status.FOR_SALE)
-        public
+        external
         returns(bool)
     {       
         sellData.value = uint256(0);
@@ -191,7 +191,7 @@ contract AssetLibrary is AssetEvents {
 
     function buy(address _buyer) payable
         hasStatus(Status.FOR_SALE)
-        public
+        external
         returns(bool)
     {
         sellData.buyer = _buyer;
@@ -202,7 +202,7 @@ contract AssetLibrary is AssetEvents {
 
      function cancelSale()
         hasStatus(Status.PENDING_INVESTOR_AGREEMENT)
-        public
+        external
         returns(bool)
     {
         require(msg.sender == protocol || msg.sender == sellData.buyer);
@@ -219,7 +219,7 @@ contract AssetLibrary is AssetEvents {
     function refuseSale()
         authorizedToSell
         hasStatus(Status.PENDING_INVESTOR_AGREEMENT)
-        public 
+        external 
         returns(bool)
     {
         address buyer = sellData.buyer;
@@ -235,7 +235,7 @@ contract AssetLibrary is AssetEvents {
     function acceptSale()
         authorizedToSell
         hasStatus(Status.PENDING_INVESTOR_AGREEMENT)
-        public
+        external
         returns(bool)
     {
         address currentInvestor = investor;
@@ -252,7 +252,7 @@ contract AssetLibrary is AssetEvents {
     function returnInvestment() payable
         onlyOwner
         hasStatus(Status.INVESTED)
-        public
+        external
         returns(bool)
     {
         investor.transfer(msg.value);
@@ -269,7 +269,7 @@ contract AssetLibrary is AssetEvents {
     function supplyFuel(uint256 _amount)
         onlyOwner
         hasStatus(Status.AVAILABLE)
-        public
+        external
         returns(bool)
     {
         assert(token.balanceOf(this) == tokenFuel + _amount);
@@ -282,7 +282,7 @@ contract AssetLibrary is AssetEvents {
         onlyInvestor
         hasStatus(Status.INVESTED)
         onlyDelayed
-        public
+        external
         returns(bool)
     {   
         return withdrawTokens(investor, tokenFuel);

--- a/contracts/investment/InvestmentAsset.sol
+++ b/contracts/investment/InvestmentAsset.sol
@@ -22,8 +22,6 @@ contract InvestmentAsset {
     address public investor;
     // Protocol version
     string public protocolVersion;
-    // Contractual terms hash of investment
-    bytes public assetTermsHash;
     // investment timestamp
     uint public investedAt;
     
@@ -60,7 +58,6 @@ contract InvestmentAsset {
         string _protocolVersion,
         string _currency,
         uint256 _value,
-        bytes _assetTermsHash,
         uint _paybackDays,
         uint _grossReturn,
         address _token)
@@ -74,7 +71,6 @@ contract InvestmentAsset {
         protocolVersion = _protocolVersion;
         currency = _currency;
         value = _value;
-        assetTermsHash = _assetTermsHash;
         paybackDays = _paybackDays;
         grossReturn = _grossReturn;
         status = Status.AVAILABLE;
@@ -85,9 +81,9 @@ contract InvestmentAsset {
     function getAsset()
         public
         constant
-        returns(address, string, uint256, uint256, uint256, Status, address, string, bytes, uint, uint256)
+        returns(address, string, uint256, uint256, uint256, Status, address, string, uint, uint256)
     {
-        return (owner, currency, value, paybackDays, grossReturn, status, investor, protocolVersion, assetTermsHash, investedAt, tokenFuel);
+        return (owner, currency, value, paybackDays, grossReturn, status, investor, protocolVersion, investedAt, tokenFuel);
     }
 
     function () payable 

--- a/contracts/investment/InvestmentAsset.sol
+++ b/contracts/investment/InvestmentAsset.sol
@@ -79,7 +79,7 @@ contract InvestmentAsset {
     }
 
     function getAsset()
-        public
+        external
         constant
         returns(address, string, uint256, uint256, uint256, Status, address, string, uint, uint256)
     {
@@ -87,7 +87,7 @@ contract InvestmentAsset {
     }
 
     function () payable 
-        public
+        external
     {
         require(assetLibrary.delegatecall(msg.data));
     }

--- a/contracts/investment/InvestmentAsset.sol
+++ b/contracts/investment/InvestmentAsset.sol
@@ -43,6 +43,8 @@ contract InvestmentAsset {
         AVAILABLE,
         PENDING_OWNER_AGREEMENT,
         INVESTED,
+        FOR_SALE,
+        PENDING_INVESTOR_AGREEMENT,
         RETURNED,
         DELAYED_RETURN
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -955,7 +955,7 @@
     "chai-bignumber": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/chai-bignumber/-/chai-bignumber-2.0.2.tgz",
-      "integrity": "sha1-3mwhnGkLLWa2Rq1pMAlvm6IZlkM="
+      "integrity": "sha512-BIdRNjRaoRj4bMsZLKbIZPMNKqmwnzNiyxqBYDSs6dFOCs9w8OHPuUE8e1bH60i1IhOzT0NjLtCD+lKEWB1KTQ=="
     },
     "chalk": {
       "version": "1.1.3",

--- a/scripts/start_testrpc.sh
+++ b/scripts/start_testrpc.sh
@@ -1,2 +1,2 @@
 testrpc_port=8545
-ganache-cli --network-id "${DEV_NETWORK_ID}" --gasLimit 0xfffffffffff  -m "${WALLET_MNEMONIC}" --port "$testrpc_port"
+ganache-cli --network-id "${DEV_NETWORK_ID}" --gasLimit 0xfffffffffff --g 100000000000  -m "${WALLET_MNEMONIC}" --port "$testrpc_port"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ start_testrpc() {
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501209,1000000000000000000000000"
   )
 
-  node_modules/.bin/ganache-cli "${accounts[@]}" > /dev/null &
+  node_modules/.bin/ganache-cli "${accounts[@]}" --g 100000000000 > /dev/null &
  
   testrpc_pid=$!
 }

--- a/test/SwapyExchange.js
+++ b/test/SwapyExchange.js
@@ -1,121 +1,130 @@
 
 // helpers
-const increaseTime  = require('./helpers/increaseTime');
-const { getBalance, getGasPrice } = require('./helpers/web3');
-const ether = require('./helpers/ether'); 
+const increaseTime  = require('./helpers/increaseTime')
+const { getBalance, getGasPrice } = require('./helpers/web3')
+const ether = require('./helpers/ether') 
 
+const BigNumber = web3.BigNumber
 const should = require('chai')
     .use(require('chai-as-promised'))
     .should()
-const expect = require('chai').expect;
-const BigNumber = web3.BigNumber;
+const expect = require('chai').expect
+
 
 // --- Handled contracts
-const SwapyExchange = artifacts.require("./SwapyExchange.sol");
-const AssetLibrary = artifacts.require("./investment/AssetLibrary.sol");
-const InvestmentAsset = artifacts.require("./investment/InvestmentAsset.sol");
-const Token = artifacts.require("./token/Token.sol");
+const SwapyExchange = artifacts.require("./SwapyExchange.sol")
+const AssetLibrary = artifacts.require("./investment/AssetLibrary.sol")
+const InvestmentAsset = artifacts.require("./investment/InvestmentAsset.sol")
+const Token = artifacts.require("./token/Token.sol")
 
 // --- Test constants
-const payback = new BigNumber(12);
-const grossReturn = new BigNumber(500);
-const assetValue = ether(5);
+const payback = new BigNumber(12)
+const grossReturn = new BigNumber(500)
+const assetValue = ether(5)
 // returned value =  invested value + return on investment
-const returnValue = new BigNumber(1 + grossReturn.toNumber()/10000).times(assetValue);
-const assets = [500,500,500,500,500];
-const offerFuel = new BigNumber(5000);
-const assetFuel = offerFuel.dividedBy(new BigNumber(assets.length));
-const currency = "USD";
-const offerTerms = "111111";
+const returnValue = new BigNumber(1 + grossReturn.toNumber()/10000).times(assetValue)
+const assets = [500,500,500,500,500]
+const offerFuel = new BigNumber(5000)
+const assetFuel = offerFuel.dividedBy(new BigNumber(assets.length))
+const currency = "USD"
+// asset status
+const AVAILABLE = new BigNumber(0)
+const PENDING_OWNER_AGREEMENT = new BigNumber(1)
+const INVESTED = new BigNumber(2)
+const FOR_SALE = new BigNumber(3)
+const PENDING_INVESTOR_AGREEMENT = new BigNumber(4) 
+const RETURNED = new BigNumber(5)
+const DELAYED_RETURN = new BigNumber(6)
 
 // --- Test variables
 // Contracts
-let token = null;
-let library = null;
-let protocol = null;
+let token = null
+let library = null
+let protocol = null
 // Assets
-let assetsAddress = [];
-let firstAsset = null;
-let secondAsset = null;
-let thirdAsset = null;
+let assetsAddress = []
+let firstAsset = null
+let secondAsset = null
+let thirdAsset = null
 // Agents
-let investor = null;
-let creditCompany = null;
-let Swapy = null;
-let secondInvestor = null;
+let investor = null
+let creditCompany = null
+let Swapy = null
+let secondInvestor = null
 // Util
-let gasPrice = null;
+let gasPrice = null
+
 
 contract('SwapyExchange', async accounts => {
 
     before( async () => {
    
-        Swapy = accounts[0];
-        creditCompany = accounts[1];
-        investor = accounts[2];
-        secondInvestor = accounts[3];
-        gasPrice = await getGasPrice();
-        gasPrice = new BigNumber(gasPrice);        
-        const library = await AssetLibrary.new({ from: Swapy });
-        token  = await Token.new({from: Swapy});
-        protocol = await SwapyExchange.new(library.address, token.address, { from: Swapy });
-        await token.transfer(creditCompany, offerFuel, {from: Swapy});
+        Swapy = accounts[0]
+        creditCompany = accounts[1]
+        investor = accounts[2]
+        secondInvestor = accounts[3]
+        gasPrice = await getGasPrice()
+        gasPrice = new BigNumber(gasPrice)        
+        const library = await AssetLibrary.new({ from: Swapy })
+        token  = await Token.new({from: Swapy})
+        protocol = await SwapyExchange.new(library.address, token.address, { from: Swapy })
+        await token.transfer(creditCompany, offerFuel, {from: Swapy})
    
     })
 
     it("should have a version", async () => {
-        const version = await protocol.VERSION.call();
+        const version = await protocol.VERSION.call()
         should.exist(version)
     })
 
-    describe('Fundraising offers', () => {
+    context('Fundraising offers', () => {
         it("should create an investment offer with assets", async () => {
             const {logs} = await protocol.createOffer(
                 payback,
                 grossReturn,
                 currency,
-                offerTerms,
                 assets,
                 {from: creditCompany}
-            );
+            )
             const event = logs.find(e => e.event === 'Offers')
-            const args = event.args;
+            const args = event.args
             expect(args).to.include.all.keys([
                 '_from',
                 '_protocolVersion',
                 '_assets'
-            ]);
-            assert.equal(args._from, creditCompany, 'The credit company must be the offer owner');
-            assert.equal(args._assets.length, assets.length, 'The count of created assets must be equal the count of sent');
-            assetsAddress = args._assets;
+            ])
+            assetsAddress = args._assets
+            assert.equal(args._from, creditCompany, 'The credit company must be the offer owner')
+            assert.equal(args._assets.length, assets.length, 'The count of created assets must be equal the count of sent')
+  
         })
     
         it("should add an investment by using the protocol", async () => {
+            const assets = [assetsAddress[0]]
             // balances before invest
-            const previousAssetBalance = await getBalance(assetsAddress[0]);
-            const previousInvestorBalance = await getBalance(investor);
-            const assets = [assetsAddress[0]];
+            const previousAssetBalance = await getBalance(assetsAddress[0])
+            const previousInvestorBalance = await getBalance(investor)
             const {logs, receipt} = await protocol.invest(
                 assets,
                 {value: assetValue, from: investor}
-            );
+            )
+                        // balances after invest
+            const currentAssetBalance = await getBalance(assetsAddress[0])
+            const currentInvestorBalance = await getBalance(investor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             const event = logs.find(e => e.event === 'Investments')
-            const args = event.args;
+            const args = event.args
             expect(args).to.include.all.keys([
                 '_investor',
                 '_assets',
                 '_value'
-            ]);
-            // balances after invest
-            const currentAssetBalance = await getBalance(assetsAddress[0]);
-            const currentInvestorBalance = await getBalance(investor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            ])
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
                 .minus(assetValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.plus(assetValue).toNumber())
         })
     })
@@ -124,62 +133,62 @@ contract('SwapyExchange', async accounts => {
 
 describe('Contract: InvestmentAsset ', async () => {
    
-    const periodAfterInvestment = new BigNumber(1/2);
+    const periodAfterInvestment = new BigNumber(1/2)
     await increaseTime(86400 * payback * periodAfterInvestment.toNumber())
-    const returnOnPeriod = returnValue.minus(assetValue).times(periodAfterInvestment);
-    const sellValue = assetValue.plus(returnOnPeriod);
+    const returnOnPeriod = returnValue.minus(assetValue).times(periodAfterInvestment)
+    const sellValue = assetValue.plus(returnOnPeriod)
 
     it('should return the asset when calling getAsset', async () => {
-        const asset = await InvestmentAsset.at(assetsAddress[0]);
-        const assetValues = await asset.getAsset();
-        assert.equal(assetValues.length, 11, "The asset must have 11 variables");
-        assert.equal(assetValues[0], creditCompany, "The asset owner must be the creditCompany");
+        const asset = await InvestmentAsset.at(assetsAddress[0])
+        const assetValues = await asset.getAsset()
+        assert.equal(assetValues.length, 11, "The asset must have 11 variables")
+        assert.equal(assetValues[0], creditCompany, "The asset owner must be the creditCompany")
     })
 
-    describe('Token Supply', () => {
+    context('Token Supply', () => {
         it("should supply tokens as fuel to the first asset", async () => {
-            await token.transfer(assetsAddress[1], assetFuel, {from: creditCompany});
-            firstAsset = await AssetLibrary.at(assetsAddress[1]);
+            await token.transfer(assetsAddress[1], assetFuel, {from: creditCompany})
+            firstAsset = await AssetLibrary.at(assetsAddress[1])
             const {logs} = await firstAsset.supplyFuel(
                 assetFuel,
                 {from: creditCompany}
-            );
+            )
             const event = logs.find(e => e.event === 'Supplied')
-            const args = event.args;
+            const args = event.args
             expect(args).to.include.all.keys([
                '_owner',
                '_amount',
                '_assetFuel'
-            ]);
+            ])
         })  
     })
     
-    describe('Invest', () => {
+    context('Invest', () => {
         it('should add an investment by using the asset', async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousInvestorBalance = await getBalance(investor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousInvestorBalance = await getBalance(investor)
             const {logs, receipt} = await firstAsset.invest(
                 investor,
                 {value: assetValue, from: investor}
-            );
+            )
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentInvestorBalance = await getBalance(investor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             const event = logs.find(e => e.event === 'Invested')
-            const args = event.args;
+            const args = event.args
             expect(args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
-            ]);
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentInvestorBalance = await getBalance(investor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            ])
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
                 .minus(assetValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.plus(assetValue).toNumber())
-        });
+        })
     
         it("should deny an investment if the asset isn't available", async () => {
             await firstAsset.invest(investor,{from: investor, value: assetValue})
@@ -187,36 +196,36 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     })
 
-    describe('Cancel Investment', () => {
+    context('Cancel Investment', () => {
         it("should deny a cancelment if the user isn't the investor", async () => {
             await firstAsset.cancelInvestment({from: creditCompany})
                 .should.be.rejectedWith('VM Exception')
         })
     
         it('should cancel a pending investment', async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousInvestorBalance = await getBalance(investor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousInvestorBalance = await getBalance(investor)
             const { logs, receipt } = await firstAsset.cancelInvestment({from: investor})
-            const event = logs.find(e => e.event === 'Canceled');
+            const event = logs.find(e => e.event === 'Canceled')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
-            ]);
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentInvestorBalance = await getBalance(investor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            ])
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentInvestorBalance = await getBalance(investor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
                 .plus(assetValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(assetValue).toNumber())
         })
     })
     
-    describe('Refuse Investment', () => {
+    context('Refuse Investment', () => {
         
         it('should add an investment', async () => {
             await firstAsset.invest(investor, {from: investor, value: assetValue})
@@ -228,28 +237,28 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     
         it('should refuse a pending investment', async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousInvestorBalance = await getBalance(investor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousInvestorBalance = await getBalance(investor)
             const {logs} = await firstAsset.refuseInvestment({ from: creditCompany })
             let event = logs.find(e => e.event === 'Refused')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
-            ]);
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentInvestorBalance = await getBalance(investor);
+            ])
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentInvestorBalance = await getBalance(investor)
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
                 .plus(assetValue)
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(assetValue).toNumber())
         })
     
     })
 
-    describe('Withdraw Funds', () => {
+    context('Withdraw Funds', () => {
 
         it('should add an investment', async () => {
             await firstAsset.invest(investor,{from: investor, value: assetValue})
@@ -261,30 +270,31 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     
         it('should accept a pending investment and withdraw funds', async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousCreditCompanyBalance = await getBalance(creditCompany);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousCreditCompanyBalance = await getBalance(creditCompany)
             const { logs, receipt } = await firstAsset.withdrawFunds( { from: creditCompany })
-            const event = logs.find(e => e.event === 'Withdrawal');
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentCreditCompanyBalance = await getBalance(creditCompany)
+            const gasUsed = new BigNumber(receipt.gasUsed)
+            const event = logs.find(e => e.event === 'Withdrawal')
+            
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
-            ]);
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentCreditCompanyBalance = await getBalance(creditCompany);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            ])
             currentCreditCompanyBalance.toNumber().should.equal(
                 previousCreditCompanyBalance
                 .plus(assetValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(assetValue).toNumber())
         })
           
     })
 
-    describe('Sell', () => {
+    context('Sell', () => {
         
         it("should deny a sell order if the user isn't the investor", async() => {
             await protocol.sellAsset(assetsAddress[1], sellValue, {from: creditCompany})
@@ -294,6 +304,7 @@ describe('Contract: InvestmentAsset ', async () => {
         it('should sell an asset by using the protocol', async() => {
             const {logs} = await protocol.sellAsset(assetsAddress[1], sellValue, {from: investor})
             const event = logs.find(e => e.event === 'ForSale')
+            
             expect(event.args).to.include.all.keys([
                 '_investor',
                 '_asset',
@@ -303,9 +314,9 @@ describe('Contract: InvestmentAsset ', async () => {
 
     })
 
-    describe('Cancel sell order', () => {
+    context('Cancel sell order', () => {
       
-        it("should deny a sell order cancelment if the user isnt't the investor", async () => {
+        it("should deny a sell order cancelment if the user isn't the investor", async () => {
             await firstAsset.cancelSellOrder({from: creditCompany})
             .should.be.rejectedWith('VM Exception')
         })
@@ -313,6 +324,7 @@ describe('Contract: InvestmentAsset ', async () => {
         it("should cancel a sell", async () => {
             const {logs} = await firstAsset.cancelSellOrder({from: investor})
             const event = logs.find(e => e.event === 'CanceledSell')
+            
             expect(event.args).to.include.all.keys([
                 '_investor',
                 '_value'
@@ -321,9 +333,9 @@ describe('Contract: InvestmentAsset ', async () => {
     
     })
 
-    describe('Buy', () => {
+    context('Buy', () => {
         
-        it("should sell an asset", async() => {
+        it("should sell an asset by using the asset", async() => {
             const {logs} = await firstAsset.sell(sellValue, {from: investor})
             const event = logs.find(e => e.event === 'ForSale')
             expect(event.args).to.include.all.keys([
@@ -333,8 +345,8 @@ describe('Contract: InvestmentAsset ', async () => {
         })
 
         it("should buy an asset by using the protocol", async () => {
-            const previousAssetBalance = await getBalance(assetsAddress[1]);
-            const previousBuyerBalance = await getBalance(secondInvestor);
+            const previousAssetBalance = await getBalance(assetsAddress[1])
+            const previousBuyerBalance = await getBalance(secondInvestor)
             const { logs, receipt } = await protocol.buyAsset(assetsAddress[1], {from: secondInvestor, value: sellValue})
             const event = logs.find(e => e.event === 'Bought')
             expect(event.args).to.include.all.keys([
@@ -342,20 +354,20 @@ describe('Contract: InvestmentAsset ', async () => {
                 '_asset',
                 '_value'
             ])
-            const currentAssetBalance = await getBalance(assetsAddress[1]);
-            const currentBuyerBalance = await getBalance(secondInvestor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            const currentAssetBalance = await getBalance(assetsAddress[1])
+            const currentBuyerBalance = await getBalance(secondInvestor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             currentBuyerBalance.toNumber().should.equal(
                 previousBuyerBalance
                 .minus(sellValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.plus(sellValue).toNumber())
         })
     })
 
-    describe('Cancel sale', () => {
+    context('Cancel sale', () => {
         
         it("should deny a sale cancelment if the user isnt't the buyer", async () => {
             await firstAsset.cancelSale({from: investor})
@@ -363,8 +375,8 @@ describe('Contract: InvestmentAsset ', async () => {
         })
 
         it("should cancel a sale", async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousBuyerBalance = await getBalance(secondInvestor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousBuyerBalance = await getBalance(secondInvestor)
             const { logs, receipt } = await firstAsset.cancelSale({from: secondInvestor})
             const event = logs.find(e => e.event === 'Canceled')
             expect(event.args).to.include.all.keys([
@@ -372,29 +384,41 @@ describe('Contract: InvestmentAsset ', async () => {
                 '_investor',
                 '_value'
             ])
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentBuyerBalance = await getBalance(secondInvestor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentBuyerBalance = await getBalance(secondInvestor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             currentBuyerBalance.toNumber().should.equal(
                 previousBuyerBalance
                 .plus(sellValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(sellValue).toNumber())
         })
     })
 
-    describe('Refuse sale', () => {
+    context('Refuse sale', () => {
         
-        it("should buy an asset", async () => {
-            const {logs} = await firstAsset.buy(secondInvestor, {value: sellValue})
+        it("should buy an asset by using the asset", async () => {
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousBuyerBalance = await getBalance(secondInvestor)
+            const { logs, receipt } = await firstAsset.buy(secondInvestor, { from: secondInvestor, value: sellValue })
             const event = logs.find(e => e.event === 'Invested')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value'
             ])
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentBuyerBalance = await getBalance(secondInvestor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
+            currentBuyerBalance.toNumber().should.equal(
+                previousBuyerBalance
+                .minus(sellValue)
+                .minus(gasPrice.times(gasUsed))
+                .toNumber()
+            )
+            currentAssetBalance.toNumber().should.equal(previousAssetBalance.plus(sellValue).toNumber())
         })
         
         it("should deny a sale refusement if the user isnt't the investor", async () => {
@@ -403,8 +427,8 @@ describe('Contract: InvestmentAsset ', async () => {
         })
 
         it("should refuse a sale", async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousBuyerBalance = await getBalance(secondInvestor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousBuyerBalance = await getBalance(secondInvestor)
             const { logs, receipt } = await firstAsset.refuseSale({from: investor})
             const event = logs.find(e => e.event === 'Refused')
             expect(event.args).to.include.all.keys([
@@ -412,22 +436,22 @@ describe('Contract: InvestmentAsset ', async () => {
                 '_investor',
                 '_value'
             ])
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentBuyerBalance = await getBalance(secondInvestor);
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentBuyerBalance = await getBalance(secondInvestor)
             currentBuyerBalance.toNumber().should.equal(
                 previousBuyerBalance
                 .plus(sellValue)
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(sellValue).toNumber())
 
         })
     })
 
-    describe('Accept sale and withdraw funds', () => {
+    context('Accept sale and withdraw funds', () => {
        
         it("should buy an asset", async () => {
-           await firstAsset.buy(secondInvestor, {value: sellValue})
+           await firstAsset.buy(secondInvestor, { value: sellValue })
         })
         it("should deny a sale acceptment if the user isnt't the investor", async () => {
             await firstAsset.acceptSale({from: secondInvestor})
@@ -435,8 +459,8 @@ describe('Contract: InvestmentAsset ', async () => {
         })
 
         it("should accept a sale", async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
-            const previousSellerBalance = await getBalance(investor);
+            const previousAssetBalance = await getBalance(firstAsset.address)
+            const previousSellerBalance = await getBalance(investor)
             const { logs, receipt } = await firstAsset.acceptSale({from: investor})
             const event = logs.find(e => e.event === 'Withdrawal')
             expect(event.args).to.include.all.keys([
@@ -444,21 +468,21 @@ describe('Contract: InvestmentAsset ', async () => {
                 '_investor',
                 '_value'
             ])
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentSellerBalance = await getBalance(investor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
+            const currentAssetBalance = await getBalance(firstAsset.address)
+            const currentSellerBalance = await getBalance(investor)
+            const gasUsed = new BigNumber(receipt.gasUsed)
             currentSellerBalance.toNumber().should.equal(
                 previousSellerBalance
                 .plus(sellValue)
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
-            );
+            )
             currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(sellValue).toNumber())
         })
     })
 
 
-    describe("Require Asset's Fuel", () => {
+    context("Require Asset's Fuel", () => {
         it("should deny the token fuel request if the return of investment isn't delayed", async () => {
             await firstAsset.requireTokenFuel({ from: secondInvestor })
                 .should.be.rejectedWith('VM Exception')
@@ -466,34 +490,32 @@ describe('Contract: InvestmentAsset ', async () => {
     
         it("should deny the token fuel request if the user isn't the investor", async () => {
             // simulate a long period after the funds transfer
-            await increaseTime(16416000);
+            await increaseTime(16416000)
             await firstAsset.requireTokenFuel({ from: creditCompany })
                .should.be.rejectedWith('VM Exception')
         })
     
         it("should send the token fuel to the asset's investor", async () => {
-            const previousInvestorTokenBalance = await token.balanceOf(secondInvestor);
-            const previousAssetTokenBalance = await token.balanceOf(firstAsset.address);
+            const previousInvestorTokenBalance = await token.balanceOf(secondInvestor)
+            const previousAssetTokenBalance = await token.balanceOf(firstAsset.address)
             const { logs, receipt } =  await firstAsset.requireTokenFuel({ from: secondInvestor })
-            const event = logs.find(e => e.event === 'TokenWithdrawal');
+            const event = logs.find(e => e.event === 'TokenWithdrawal')
             expect(event.args).to.include.all.keys([
                 '_to',
                 '_amount'
-            ]);
-            const currentInvestorTokenBalance = await getBalance(secondInvestor);
-            const currentAssetTokenBalance = await getBalance(firstAsset.address);
-            console.log(previousInvestorTokenBalance.plus(assetFuel));
-            console.log(currentInvestorTokenBalance);
+            ])
+            const currentInvestorTokenBalance = await token.balanceOf(secondInvestor)
+            const currentAssetTokenBalance = await token.balanceOf(firstAsset.address)
             currentInvestorTokenBalance.toNumber().should.equal(
                 previousInvestorTokenBalance
                 .plus(assetFuel)
                 .toNumber()
-            );
+            )
             currentAssetTokenBalance.toNumber().should.equal(previousAssetTokenBalance.minus(assetFuel).toNumber())
         })  
     })
 
-    describe('Delayed return without remaining tokens', () => {
+    context('Delayed return without remaining tokens', () => {
     
         it("should deny an investment return if the user isn't the asset owner", async () => {
             await firstAsset.returnInvestment({ from: secondInvestor, value: returnValue }) 
@@ -501,83 +523,72 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     
         it('should return the investment with delay', async () => {
-            const previousInvestorBalance = await getBalance(secondInvestor);
+            const previousInvestorBalance = await getBalance(secondInvestor)
             const { logs, receipt } = await firstAsset.returnInvestment({ from: creditCompany, value: returnValue })
-            const event = logs.find(e => e.event === 'Returned');
+            const event = logs.find(e => e.event === 'Returned')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
                 '_delayed'
-            ]);
-            assert.equal(event.args._delayed,true,"The investment must be returned with delay");
-            const currentInvestorBalance = await getBalance(secondInvestor);
+            ])
+            assert.equal(event.args._delayed,true,"The investment must be returned with delay")
+            const currentInvestorBalance = await getBalance(secondInvestor)
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
                 .plus(returnValue)
                 .toNumber()
-            );
+            )
         })
         
     })
    
-    describe('Delayed return with remaining tokens', () => {
+    context('Delayed return with remaining tokens', () => {
         it("should supply tokens to the second asset", async () => {
-            await token.transfer(assetsAddress[2], assetFuel, {from: creditCompany});
-            secondAsset = await AssetLibrary.at(assetsAddress[2]);
-            await secondAsset.supplyFuel(
-                assetFuel,
-                {from: creditCompany}
-            );
+            await token.transfer(assetsAddress[2], assetFuel, {from: creditCompany})
+            secondAsset = await AssetLibrary.at(assetsAddress[2])
+            await secondAsset.supplyFuel(assetFuel, { from: creditCompany })
         })  
         
         it('should add an investment', async () => {
-            secondAsset = await AssetLibrary.at(assetsAddress[2]);
+            secondAsset = await AssetLibrary.at(assetsAddress[2])
             await secondAsset.invest(investor,{from: investor, value: assetValue})
         })
     
         it('should accept a pending investment and withdraw funds', async () => {
-            const {logs} =  await secondAsset.withdrawFunds({from: creditCompany})
-            const event = logs.find(e => e.event === 'Withdrawal');
-            expect(event.args).to.include.all.keys([
-                '_owner',
-                '_investor',
-                '_value',
-            ]);
+            await secondAsset.withdrawFunds({from: creditCompany})
         })
     
         it("should return the investment with delay and send tokens to the asset's investor", async () => {
             // simulate a long period after the funds transfer
-            await increaseTime(16416000);
-            const investorTokenBalance = await token.balanceOf(investor);
-            const assetTokenBalance = await token.balanceOf(secondAsset.address);
-            const {logs} = await secondAsset.returnInvestment({ from: creditCompany, value: returnValue })
-            const event = logs.find(e => e.event === 'Returned');
+            await increaseTime(16416000)
+            const previousInvestorTokenBalance = await token.balanceOf(investor)
+            const previousAssetTokenBalance = await token.balanceOf(secondAsset.address)
+            const { logs, receipt } = await secondAsset.returnInvestment({ from: creditCompany, value: returnValue })
+            const event = logs.find(e => e.event === 'Returned')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
                 '_delayed'
-            ]);
-            assert.equal(event.args._delayed,true,"The investment must be returned with delay");
-            const currentInvestorTokenBalance = await token.balanceOf(investor);
-            assert.equal(
-                investorTokenBalance.toNumber() + assetTokenBalance.toNumber(),
-                currentInvestorTokenBalance.toNumber(),
-                "The investor must receive the asset's fuel if the investment is returned with delay"
+            ])
+            assert.equal(event.args._delayed,true,"The investment must be returned with delay")
+            const currentInvestorTokenBalance = await token.balanceOf(investor)
+            const currentAssetTokenBalance = await token.balanceOf(secondAsset.address)
+            currentInvestorTokenBalance.toNumber().should.equal(
+                previousInvestorTokenBalance
+                .plus(assetFuel)
+                .toNumber()
             )
+            currentAssetTokenBalance.toNumber().should.equal(previousAssetTokenBalance.minus(assetFuel).toNumber())
         })
-        
     })
 
-    describe('Correct return with remaining tokens', () => {
+    context('Correct return with remaining tokens', () => {
         it("should supply tokens to the third asset", async () => {
-            await token.transfer(assetsAddress[3], assetFuel, {from: creditCompany});
-            thirdAsset = await AssetLibrary.at(assetsAddress[3]);
-            await thirdAsset.supplyFuel(
-                assetFuel,
-                {from: creditCompany}
-            );
+            await token.transfer(assetsAddress[3], assetFuel, {from: creditCompany})
+            thirdAsset = await AssetLibrary.at(assetsAddress[3])
+            await thirdAsset.supplyFuel(assetFuel, { from: creditCompany })
         }) 
     
         it('should add an investment', async () => {
@@ -585,33 +596,29 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     
         it('should accept a pending investment and withdraw funds', async () => {
-            const {logs} =  await thirdAsset.withdrawFunds({from: creditCompany})
-            const event = logs.find(e => e.event === 'Withdrawal');
-            expect(event.args).to.include.all.keys([
-                '_owner',
-                '_investor',
-                '_value',
-            ]);
+            await thirdAsset.withdrawFunds({from: creditCompany})
         })
         
         it("should return the investment correctly and send tokens to the asset's owner", async () => {
-            const creditCoTokenBalance = await token.balanceOf(creditCompany);
-            const assetTokenBalance = await token.balanceOf(thirdAsset.address);
-            const {logs} = await thirdAsset.returnInvestment({ from: creditCompany, value: returnValue })
-            const event = logs.find(e => e.event === 'Returned');
+            const previousCreditCompanyTokenBalance = await token.balanceOf(creditCompany)
+            const previousAssetTokenBalance = await token.balanceOf(thirdAsset.address)
+            const { logs } = await thirdAsset.returnInvestment({ from: creditCompany, value: returnValue })
+            const event = logs.find(e => e.event === 'Returned')
             expect(event.args).to.include.all.keys([
                 '_owner',
                 '_investor',
                 '_value',
                 '_delayed'
-            ]);
-            assert.equal(event.args._delayed,false,"The investment must be returned without delay");
-            const currentCreditCoTokenBalance = await token.balanceOf(creditCompany);
-            assert.equal(
-                creditCoTokenBalance.toNumber() + assetTokenBalance.toNumber(),
-                currentCreditCoTokenBalance.toNumber(),
-                "The credit company must receive the asset's fuel if the investment is returned without delay"
+            ])
+            assert.equal(event.args._delayed,false,"The investment must be returned without delay")
+            const currentCreditCompanyTokenBalance = await token.balanceOf(creditCompany)
+            const currentAssetTokenBalance = await token.balanceOf(thirdAsset.address)
+            currentCreditCompanyTokenBalance.toNumber().should.equal(
+                previousCreditCompanyTokenBalance
+                .plus(assetFuel)
+                .toNumber()
             )
+            currentAssetTokenBalance.toNumber().should.equal(previousAssetTokenBalance.minus(assetFuel).toNumber())
         })
     })
 

--- a/test/SwapyExchange.js
+++ b/test/SwapyExchange.js
@@ -381,7 +381,7 @@ describe('Contract: InvestmentAsset ', async () => {
                 .minus(gasPrice.times(gasUsed))
                 .toNumber()
             );
-            currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(assetValue).toNumber())
+            currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(sellValue).toNumber())
         })
     })
 
@@ -474,22 +474,22 @@ describe('Contract: InvestmentAsset ', async () => {
         it("should send the token fuel to the asset's investor", async () => {
             const previousInvestorTokenBalance = await token.balanceOf(secondInvestor);
             const previousAssetTokenBalance = await token.balanceOf(firstAsset.address);
-            const { logs } =  await firstAsset.requireTokenFuel({ from: secondInvestor })
+            const { logs, receipt } =  await firstAsset.requireTokenFuel({ from: secondInvestor })
             const event = logs.find(e => e.event === 'TokenWithdrawal');
             expect(event.args).to.include.all.keys([
                 '_to',
                 '_amount'
             ]);
-            const currentAssetBalance = await getBalance(firstAsset.address);
-            const currentSellerBalance = await getBalance(investor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
-            currentSellerBalance.toNumber().should.equal(
-                previousSellerBalance
-                .plus(sellValue)
-                .minus(gasPrice.times(gasUsed))
+            const currentInvestorTokenBalance = await getBalance(secondInvestor);
+            const currentAssetTokenBalance = await getBalance(firstAsset.address);
+            console.log(previousInvestorTokenBalance.plus(assetFuel));
+            console.log(currentInvestorTokenBalance);
+            currentInvestorTokenBalance.toNumber().should.equal(
+                previousInvestorTokenBalance
+                .plus(assetFuel)
                 .toNumber()
             );
-            currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(sellValue).toNumber())
+            currentAssetTokenBalance.toNumber().should.equal(previousAssetTokenBalance.minus(assetFuel).toNumber())
         })  
     })
 
@@ -501,7 +501,6 @@ describe('Contract: InvestmentAsset ', async () => {
         })
     
         it('should return the investment with delay', async () => {
-            const previousAssetBalance = await getBalance(firstAsset.address);
             const previousInvestorBalance = await getBalance(secondInvestor);
             const { logs, receipt } = await firstAsset.returnInvestment({ from: creditCompany, value: returnValue })
             const event = logs.find(e => e.event === 'Returned');
@@ -512,16 +511,12 @@ describe('Contract: InvestmentAsset ', async () => {
                 '_delayed'
             ]);
             assert.equal(event.args._delayed,true,"The investment must be returned with delay");
-            const currentAssetBalance = await getBalance(firstAsset.address);
             const currentInvestorBalance = await getBalance(secondInvestor);
-            const gasUsed = new BigNumber(receipt.gasUsed);
             currentInvestorBalance.toNumber().should.equal(
                 previousInvestorBalance
-                .plus(assetValue)
-                .minus(gasPrice.times(gasUsed))
+                .plus(returnValue)
                 .toNumber()
             );
-            currentAssetBalance.toNumber().should.equal(previousAssetBalance.minus(assetValue).toNumber())
         })
         
     })

--- a/test/helpers/ether.js
+++ b/test/helpers/ether.js
@@ -1,0 +1,4 @@
+module.exports = (n) => {
+    return new web3.BigNumber(web3.toWei(n, 'ether'))
+}
+  

--- a/test/helpers/web3.js
+++ b/test/helpers/web3.js
@@ -1,0 +1,75 @@
+
+module.exports = {
+
+    getBalance(addr) {
+      return new Promise((resolve, reject) => {
+        web3.eth.getBalance(addr, async (err, res) => {
+          if (err || !res) return reject(err)
+          resolve(res)
+        })
+      })
+    },
+  
+    getBlockNumber() {
+      return new Promise((resolve, reject) => {
+        web3.eth.getBlockNumber(async (err, res) => {
+          if (err || !res) return reject(err)
+          resolve(res)
+        })
+      })
+    },
+  
+    getBlock(n) {
+      return new Promise(async (resolve, reject) => {
+        web3.eth.getBlock(n, (err, res) => {
+          if (err || !res) return reject(err)
+          resolve(res)
+        })
+      })
+    },
+  
+    sendTransaction(payload) {
+      return new Promise((resolve, reject) => {
+        web3.eth.sendTransaction(payload, async (err, res) => {
+          if (err || !res) return reject(err)
+          resolve(res)
+        })
+      })
+    },
+  
+    getNonce(web3) {
+      return new Promise((resolve, reject) => {
+        web3.eth.getAccounts((err, acc) => {
+          if (err) return reject(err)
+          web3.eth.getTransactionCount(acc[0], (err, n) => {
+            if (err) return reject(err)
+            resolve(n)
+          })
+        })
+      })
+    },
+  
+    sign(payload, address) {
+      return new Promise((resolve, reject) => {
+        web3.eth.sign(address, payload, async (err, signedPayload) => {
+          if (err || !signedPayload) return reject(err)
+          const adding0x = x => '0x'.concat(x)
+          resolve({
+            r: adding0x(signedPayload.substr(2, 64)),
+            s: adding0x(signedPayload.substr(66, 64)),
+            v: signedPayload.substr(130, 2) == '00' ? 27 : 28,
+          })
+        })
+      })
+    },
+
+    getGasPrice() {
+      return new Promise((resolve, reject) => {
+        web3.eth.getGasPrice(async (err, res) => {
+          if (err || !res) return reject(err)
+          resolve(res)
+        })
+      })
+    },
+
+}


### PR DESCRIPTION
* contracts:
   * add "indexed" keyword to allow the use of some event's parameters as filters.
   * use "external" instead of "public" to minimize the gas usage
   * remove contractual terms hash from InvestmentAsset
* unit tests:
   * Check the difference of ether/token balances before and after transactions 